### PR TITLE
P22-3807 Parameterized non-latin/chinese encoding on text method

### DIFF
--- a/lib/esc_pos_utils_platform/src/generator.dart
+++ b/lib/esc_pos_utils_platform/src/generator.dart
@@ -7,10 +7,11 @@
  */
 
 import 'dart:convert';
+import 'package:enough_convert/enough_convert.dart' show gbk;
 import 'package:flutter/services.dart';
 import 'package:flutter_pos_printer_platform/src/ext.dart';
 import 'package:image/image.dart' as img;
-import 'package:gbk_codec/gbk_codec.dart';
+import 'package:gbk_codec/gbk_codec.dart' as gbk2;
 import "package:hex/hex.dart";
 import '../esc_pos_utils_platform.dart';
 import 'commands.dart';
@@ -68,7 +69,7 @@ class Generator {
     return charsPerLine;
   }
 
-  Uint8List _encode(String text, {bool isKanji = false}) {
+  Uint8List _encode(String text, {bool isKanji = false, String? nonLatinEncoding}) {
     // replace some non-ascii characters
     text = text
         .replaceAll("’", "'")
@@ -81,8 +82,14 @@ class Generator {
       text = text.replaceNonPrintable(replaceWith: '');
       return latin1.encode(text);
     } else {
-      return utf8.encode(text);
-      return Uint8List.fromList(gbk_bytes.encode(text));
+      late List<int> encodedText;
+      if (nonLatinEncoding == "GBK") {
+        encodedText = gbk.encode(text);
+      } else {
+        encodedText = utf8.encode(text);
+      }
+      return Uint8List.fromList(encodedText);
+      // return Uint8List.fromList(gbk_bytes.encode(text));
     }
   }
 
@@ -347,6 +354,7 @@ class Generator {
     int linesAfter = 0,
     bool containsChinese = false,
     int? maxCharsPerLine,
+    String? nonLatinEncoding,
   }) {
     List<int> bytes = List.empty(growable: true);
     if (!containsChinese) {
@@ -359,8 +367,7 @@ class Generator {
       // Ensure at least one line break after the text
       bytes += emptyLines(linesAfter + 1);
     } else {
-      bytes += _mixedKanji(text/*.replaceNonAscii().replaceNonPrintable(replaceWith: '')*/,
-          styles: styles, linesAfter: linesAfter);
+      bytes += _mixedKanji(text, styles: styles, linesAfter: linesAfter, nonLatinEncoding: nonLatinEncoding);
     }
     return bytes;
   }
@@ -756,6 +763,7 @@ class Generator {
     PosStyles styles = const PosStyles(),
     int linesAfter = 0,
     int? maxCharsPerLine,
+    String? nonLatinEncoding,
   }) {
     List<int> bytes = List.empty(growable: true);
     final list = _getLexemes(text, containsChinese: true);
@@ -766,7 +774,7 @@ class Generator {
     int? colInd = 0;
     for (var i = 0; i < lexemes.length; ++i) {
       bytes += _text(
-        _encode(lexemes[i], isKanji: isLexemeChinese[i]),
+        _encode(lexemes[i], isKanji: isLexemeChinese[i], nonLatinEncoding: nonLatinEncoding),
         styles: styles,
         colInd: colInd,
         isKanji: isLexemeChinese[i],

--- a/lib/esc_pos_utils_platform/src/generator.dart
+++ b/lib/esc_pos_utils_platform/src/generator.dart
@@ -89,7 +89,7 @@ class Generator {
         encodedText = utf8.encode(text);
       }
       return Uint8List.fromList(encodedText);
-      // return Uint8List.fromList(gbk_bytes.encode(text));
+      // return Uint8List.fromList(gbk2.gbk_bytes.encode(text));
     }
   }
 

--- a/lib/esc_pos_utils_platform/src/generator.dart
+++ b/lib/esc_pos_utils_platform/src/generator.dart
@@ -76,17 +76,21 @@ class Generator {
         .replaceAll("»", '"')
         .replaceAll(" ", ' ')
         .replaceAll("•", '.')
-        .replaceNonAscii()
-        .replaceNonPrintable(replaceWith: '');
+        .replaceNonAscii();
     if (!isKanji) {
+      text = text.replaceNonPrintable(replaceWith: '');
       return latin1.encode(text);
     } else {
+      return utf8.encode(text);
       return Uint8List.fromList(gbk_bytes.encode(text));
     }
   }
 
-  List _getLexemes(String text) {
-    String textCleaned = text.replaceNonAscii().replaceNonPrintable(replaceWith: '');
+  List _getLexemes(String text, {bool containsChinese = false}) {
+    String textCleaned = text.replaceNonAscii();
+    if (!containsChinese) {
+      textCleaned = textCleaned.replaceNonPrintable(replaceWith: '');
+    }
     final List<String> lexemes = List.empty(growable: true);
     final List<bool> isLexemeChinese = List.empty(growable: true);
     int start = 0;
@@ -355,7 +359,7 @@ class Generator {
       // Ensure at least one line break after the text
       bytes += emptyLines(linesAfter + 1);
     } else {
-      bytes += _mixedKanji(text.replaceNonAscii().replaceNonPrintable(replaceWith: ''),
+      bytes += _mixedKanji(text/*.replaceNonAscii().replaceNonPrintable(replaceWith: '')*/,
           styles: styles, linesAfter: linesAfter);
     }
     return bytes;
@@ -754,7 +758,7 @@ class Generator {
     int? maxCharsPerLine,
   }) {
     List<int> bytes = List.empty(growable: true);
-    final list = _getLexemes(text);
+    final list = _getLexemes(text, containsChinese: true);
     final List<String> lexemes = list[0];
     final List<bool> isLexemeChinese = list[1];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   gbk_codec: ^0.4.0
   hex: ^0.2.0
   dart_ping: ^9.0.1
+  enough_convert: ^1.6.0 # provide more reliable GBK encoding than gbk_codec
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Changes:
- Add nonLatinEncoding param to generator.text (ie: "UTF-8", "GBK")
- Replace gbk encoder with more reliable library